### PR TITLE
feat(autohunt): add autonomous bootstrap planning lane

### DIFF
--- a/clients/cli/src/hooks/useAgent.test.tsx
+++ b/clients/cli/src/hooks/useAgent.test.tsx
@@ -53,6 +53,9 @@ describe("useAgent — engagement handoff lifecycle", () => {
     vi.stubEnv("DECEPTICON_ASSISTANT_ID", "soundwave");
     vi.stubEnv("DECEPTICON_ENGAGEMENT", "eng-abc");
     vi.stubEnv("DECEPTICON_WORKSPACE_PATH", "/tmp/ws");
+    vi.stubEnv("DECEPTICON_TARGET_TYPE", "web_url");
+    vi.stubEnv("DECEPTICON_TARGET", "https://target.example");
+    vi.stubEnv("DECEPTICON_AUTHORIZATION_CONFIRMED", "true");
     delete process.env.DECEPTICON_THREAD_ID;
     mockState.client = createMockClient();
     ({ useAgent } = await import("./useAgent.js"));
@@ -193,6 +196,8 @@ describe("useAgent — engagement handoff lifecycle", () => {
       const inputJson = JSON.stringify(opts.input);
       expect(inputJson).not.toContain("engagement_name");
       expect(inputJson).not.toContain("workspace_path");
+      expect(inputJson).not.toContain("target_value");
+      expect(inputJson).not.toContain("authorization_confirmed");
 
       // Engagement fields must be present in config.configurable for every
       // run (the env vars are set for the full test, so both submits route
@@ -202,6 +207,9 @@ describe("useAgent — engagement handoff lifecycle", () => {
       expect(configurable).toMatchObject({
         engagement_name: "eng-abc",
         workspace_path: "/tmp/ws",
+        target_type: "web_url",
+        target_value: "https://target.example",
+        authorization_confirmed: true,
       });
     }
   });

--- a/clients/cli/src/hooks/useAgent.ts
+++ b/clients/cli/src/hooks/useAgent.ts
@@ -775,6 +775,13 @@ export function useAgent({
           configurable.workspace_path =
             process.env.DECEPTICON_WORKSPACE_PATH ?? "/workspace";
         }
+        const targetValue = process.env.DECEPTICON_TARGET;
+        if (targetValue) {
+          configurable.target_value = targetValue;
+          configurable.target_type = process.env.DECEPTICON_TARGET_TYPE ?? "";
+          configurable.authorization_confirmed =
+            process.env.DECEPTICON_AUTHORIZATION_CONFIRMED === "true";
+        }
         const modelOverride = getModelOverride();
         if (modelOverride) {
           configurable.model_override = modelOverride;

--- a/clients/cli/src/utils/agents.ts
+++ b/clients/cli/src/utils/agents.ts
@@ -11,8 +11,9 @@ export const AGENT_LABELS: Record<string, string> = {
   // Orchestrator
   decepticon: "Decepticon",
 
-  // Document generation (stable graph id, Autohunt display name)
-  soundwave: "Autohunt",
+  // Document generation
+  soundwave: "Soundwave",
+  autohunt: "Autohunt",
 
   // Kill chain
   recon: "Recon",

--- a/clients/cli/src/utils/agents.ts
+++ b/clients/cli/src/utils/agents.ts
@@ -11,8 +11,8 @@ export const AGENT_LABELS: Record<string, string> = {
   // Orchestrator
   decepticon: "Decepticon",
 
-  // Document generation
-  soundwave: "Soundwave",
+  // Document generation (stable graph id, Autohunt display name)
+  soundwave: "Autohunt",
 
   // Kill chain
   recon: "Recon",

--- a/clients/web/prisma/migrations/20260826090000_engagement_authorization_confirmation/migration.sql
+++ b/clients/web/prisma/migrations/20260826090000_engagement_authorization_confirmation/migration.sql
@@ -1,0 +1,2 @@
+-- Autohunt requires an explicit persisted authorization signal before planning.
+ALTER TABLE "Engagement" ADD COLUMN "authorizationConfirmed" BOOLEAN NOT NULL DEFAULT false;

--- a/clients/web/prisma/schema.prisma
+++ b/clients/web/prisma/schema.prisma
@@ -26,11 +26,12 @@ enum EngagementStatus {
 // ── Application models ───────────────────────────────────────────────
 
 model Engagement {
-  id          String           @id @default(cuid())
-  name        String
-  targetType  TargetType
-  targetValue String
-  status      EngagementStatus @default(draft)
+  id                     String           @id @default(cuid())
+  name                   String
+  targetType             TargetType
+  targetValue            String
+  authorizationConfirmed Boolean          @default(false)
+  status                 EngagementStatus @default(draft)
 
   // Self-hosted single-user mode — userId is always "local".
   userId      String           @default("local")

--- a/clients/web/server/terminal-server.ts
+++ b/clients/web/server/terminal-server.ts
@@ -142,7 +142,9 @@ wss.on("connection", async (ws: WebSocket, req) => {
   const engagementId = url.searchParams.get("engagementId") ?? "";
   const engagementSlug = url.searchParams.get("engagementSlug") ?? "";
   const agentId = url.searchParams.get("agentId") ?? "soundwave";
-
+  const targetType = url.searchParams.get("targetType") ?? "";
+  const targetValue = url.searchParams.get("targetValue") ?? "";
+  const authorizationConfirmed = url.searchParams.get("authorizationConfirmed") === "true";
   if (!engagementSlug) {
     ws.close(1008, "Missing engagementSlug");
     return;
@@ -212,6 +214,9 @@ wss.on("connection", async (ws: WebSocket, req) => {
     DECEPTICON_ENGAGEMENT: engagementSlug,
     DECEPTICON_WORKSPACE_PATH: engagementSlug ? `/workspace/${engagementSlug}` : "/workspace",
     DECEPTICON_API_URL: LANGGRAPH_API_URL,
+    DECEPTICON_TARGET_TYPE: targetType,
+    DECEPTICON_TARGET: targetValue,
+    DECEPTICON_AUTHORIZATION_CONFIRMED: authorizationConfirmed ? "true" : "false",
   };
   if (threadId) env.DECEPTICON_THREAD_ID = threadId;
 

--- a/clients/web/src/app/(dashboard)/engagements/[id]/layout.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/[id]/layout.tsx
@@ -25,7 +25,12 @@ export default function EngagementLayout({
   const pathname = usePathname();
   const engagementId = params.id as string;
 
-  const [engagement, setEngagement] = useState<{ name: string } | null>(null);
+  const [engagement, setEngagement] = useState<{
+    name: string;
+    targetType: string;
+    targetValue: string;
+    authorizationConfirmed: boolean;
+  } | null>(null);
   const [agentId, setAgentId] = useState<"soundwave" | "decepticon" | null>(null);
   const [threadId, setThreadId] = useState<string | null>(null);
 
@@ -39,7 +44,13 @@ export default function EngagementLayout({
           fetch(`/api/engagements/${engagementId}/plan-docs`),
         ]);
         if (!engRes.ok) return;
-        const eng = (await engRes.json()) as { name: string; threadId?: string | null };
+        const eng = (await engRes.json()) as {
+          name: string;
+          targetType: string;
+          targetValue: string;
+          authorizationConfirmed: boolean;
+          threadId?: string | null;
+        };
         const planDocs = planRes.ok ? ((await planRes.json()) as Record<string, unknown>) : {};
         if (cancelled) return;
         setEngagement(eng);
@@ -89,6 +100,9 @@ export default function EngagementLayout({
             <WebTerminal
               engagementId={engagementId}
               engagementSlug={engagement!.name}
+              targetType={engagement!.targetType}
+              targetValue={engagement!.targetValue}
+              authorizationConfirmed={engagement!.authorizationConfirmed}
               agentId={agentId!}
               threadId={threadId ?? undefined}
               className="h-full"

--- a/clients/web/src/app/(dashboard)/engagements/new/page.tsx
+++ b/clients/web/src/app/(dashboard)/engagements/new/page.tsx
@@ -15,6 +15,7 @@ export default function NewEngagementPage() {
   const [targetType, setTargetType] = useState("web_url");
   const [name, setName] = useState("");
   const [targetValue, setTargetValue] = useState("");
+  const [authorizationConfirmed, setAuthorizationConfirmed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,8 +26,8 @@ export default function NewEngagementPage() {
       : null;
 
   async function handleSubmit() {
-    if (!nameValid || !targetValue.trim()) {
-      setError("Please fill in all required fields");
+    if (!nameValid || !targetValue.trim() || !authorizationConfirmed) {
+      setError("Enter one target and confirm explicit authorization before creating an engagement");
       return;
     }
 
@@ -37,7 +38,7 @@ export default function NewEngagementPage() {
       const res = await fetch("/api/engagements", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, targetType, targetValue }),
+        body: JSON.stringify({ name, targetType, targetValue, authorizationConfirmed }),
       });
 
       if (!res.ok) {
@@ -152,11 +153,32 @@ export default function NewEngagementPage() {
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Authorization</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <label className="flex cursor-pointer items-start gap-3 text-sm">
+            <input
+              type="checkbox"
+              checked={authorizationConfirmed}
+              onChange={(event) => setAuthorizationConfirmed(event.target.checked)}
+              className="mt-0.5 h-4 w-4"
+            />
+            <span>
+              I confirm I am authorized to test exactly the declared target. This does
+              not authorize adjacent assets, destructive testing, DoS, social
+              engineering, uncontrolled data mutation, or scope expansion.
+            </span>
+          </label>
+        </CardContent>
+      </Card>
+
       <div className="flex justify-end gap-3">
         <Button variant="outline" onClick={() => router.back()}>
           Cancel
         </Button>
-        <Button onClick={handleSubmit} disabled={submitting || !nameValid}>
+        <Button onClick={handleSubmit} disabled={submitting || !nameValid || !authorizationConfirmed}>
           {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Create Engagement
         </Button>

--- a/clients/web/src/app/api/engagements/route.ts
+++ b/clients/web/src/app/api/engagements/route.ts
@@ -68,11 +68,17 @@ export async function POST(req: NextRequest) {
     const { userId } = await requireAuth();
 
     const body = await req.json();
-    const { name, targetType, targetValue } = body;
+    const { name, targetType, targetValue, authorizationConfirmed } = body;
 
     if (!name || !targetType || !targetValue) {
       return NextResponse.json(
         { error: "Missing required fields: name, targetType, targetValue" },
+        { status: 400 }
+      );
+    }
+    if (authorizationConfirmed !== true) {
+      return NextResponse.json(
+        { error: "Explicit authorization confirmation is required" },
         { status: 400 }
       );
     }
@@ -114,6 +120,7 @@ export async function POST(req: NextRequest) {
         targetValue,
         userId,
         workspacePath: wsPath,
+        authorizationConfirmed,
       },
     });
 

--- a/clients/web/src/components/terminal/web-terminal.tsx
+++ b/clients/web/src/components/terminal/web-terminal.tsx
@@ -42,6 +42,9 @@ function sanitizeTermBytes(s: string): string {
 interface WebTerminalProps {
   engagementId: string;
   engagementSlug: string;
+  targetType: string;
+  targetValue: string;
+  authorizationConfirmed: boolean;
   agentId?: string;
   threadId?: string;
   className?: string;
@@ -51,6 +54,9 @@ interface WebTerminalProps {
 export function WebTerminal({
   engagementId,
   engagementSlug,
+  targetType,
+  targetValue,
+  authorizationConfirmed,
   agentId = "soundwave",
   threadId,
   className,
@@ -67,6 +73,12 @@ export function WebTerminal({
   agentIdRef.current = agentId;
   const threadIdRef = useRef(threadId);
   threadIdRef.current = threadId;
+  const targetTypeRef = useRef(targetType);
+  targetTypeRef.current = targetType;
+  const targetValueRef = useRef(targetValue);
+  targetValueRef.current = targetValue;
+  const authorizationConfirmedRef = useRef(authorizationConfirmed);
+  authorizationConfirmedRef.current = authorizationConfirmed;
   const onThreadIdRef = useRef(onThreadId);
   onThreadIdRef.current = onThreadId;
 
@@ -122,11 +134,17 @@ export function WebTerminal({
     const slug = engagementSlugRef.current;
     const aid = agentIdRef.current;
     const tid = threadIdRef.current;
+    const targetType = targetTypeRef.current;
+    const targetValue = targetValueRef.current;
+    const authorizationConfirmed = authorizationConfirmedRef.current;
 
     let wsUrl =
       `${TERMINAL_WS_URL}?engagementId=${encodeURIComponent(eid)}` +
       `&engagementSlug=${encodeURIComponent(slug)}` +
-      `&agentId=${encodeURIComponent(aid)}`;
+      `&agentId=${encodeURIComponent(aid)}` +
+      `&targetType=${encodeURIComponent(targetType)}` +
+      `&targetValue=${encodeURIComponent(targetValue)}` +
+      `&authorizationConfirmed=${authorizationConfirmed}`;
     if (tid) wsUrl += `&threadId=${encodeURIComponent(tid)}`;
 
     const ws = new WebSocket(wsUrl);

--- a/clients/web/src/lib/agents.ts
+++ b/clients/web/src/lib/agents.ts
@@ -65,9 +65,13 @@ export const AGENT_DISPLAY_CONFIG: Record<string, AgentDisplayMeta> = {
     color: "#ef4444",
     imagePath: "/agents/decepticon.png",
   },
-  // `soundwave` remains the deployed graph identifier during the Autohunt
-  // compatibility transition.
   soundwave: {
+    name: "Soundwave",
+    description: "Socratic interview — generates the engagement plan",
+    role: "Planning",
+    color: "#8b5cf6",
+  },
+  autohunt: {
     name: "Autohunt",
     description: "Autonomous bootstrap — plans one declared authorized target",
     role: "Planning",

--- a/clients/web/src/lib/agents.ts
+++ b/clients/web/src/lib/agents.ts
@@ -65,9 +65,11 @@ export const AGENT_DISPLAY_CONFIG: Record<string, AgentDisplayMeta> = {
     color: "#ef4444",
     imagePath: "/agents/decepticon.png",
   },
+  // `soundwave` remains the deployed graph identifier during the Autohunt
+  // compatibility transition.
   soundwave: {
-    name: "Soundwave",
-    description: "Socratic interview — generates RoE, CONOPS, OPPLAN",
+    name: "Autohunt",
+    description: "Autonomous bootstrap — plans one declared authorized target",
     role: "Planning",
     color: "#8b5cf6",
   },

--- a/langgraph.json
+++ b/langgraph.json
@@ -3,6 +3,7 @@
   "graphs": {
     "decepticon": "./packages/decepticon/decepticon/agents/standard/decepticon.py:graph",
     "recon": "./packages/decepticon/decepticon/agents/standard/recon.py:graph",
+    "autohunt": "./packages/decepticon/decepticon/agents/standard/autohunt.py:graph",
     "soundwave": "./packages/decepticon/decepticon/agents/standard/soundwave.py:graph",
     "exploit": "./packages/decepticon/decepticon/agents/standard/exploit.py:graph",
     "postexploit": "./packages/decepticon/decepticon/agents/standard/postexploit.py:graph",

--- a/packages/decepticon-core/decepticon_core/types/llm.py
+++ b/packages/decepticon-core/decepticon_core/types/llm.py
@@ -546,6 +546,7 @@ AGENT_TIERS: dict[str, Tier] = {
     "supply_chain_operator": Tier.MID,
     # LOW — high-throughput, low reasoning depth. Recon / triage / docs.
     "soundwave": Tier.LOW,
+    "autohunt": Tier.LOW,
     "recon": Tier.LOW,
     "scanner": Tier.LOW,
     "wireless_operator": Tier.LOW,
@@ -555,6 +556,7 @@ AGENT_TIERS: dict[str, Tier] = {
 AGENT_TEMPERATURES: dict[str, float] = {
     "decepticon": 0.4,
     "soundwave": 0.4,
+    "autohunt": 0.4,
     "exploit": 0.3,
     "exploiter": 0.2,
     "detector": 0.2,

--- a/packages/decepticon/decepticon/agents/__init__.py
+++ b/packages/decepticon/decepticon/agents/__init__.py
@@ -8,8 +8,8 @@ from decepticon.agents.plugins.scanner import create_scanner_agent
 from decepticon.agents.plugins.verifier import create_verifier_agent
 from decepticon.agents.plugins.vulnresearch import create_vulnresearch_agent
 from decepticon.agents.standard.ad_operator import create_ad_operator_agent
-from decepticon.agents.standard.autohunt import create_autohunt_agent
 from decepticon.agents.standard.analyst import create_analyst_agent
+from decepticon.agents.standard.autohunt import create_autohunt_agent
 from decepticon.agents.standard.blue_cell import create_blue_cell_agent
 from decepticon.agents.standard.cloud_hunter import create_cloud_hunter_agent
 from decepticon.agents.standard.contract_auditor import create_contract_auditor_agent

--- a/packages/decepticon/decepticon/agents/__init__.py
+++ b/packages/decepticon/decepticon/agents/__init__.py
@@ -8,6 +8,7 @@ from decepticon.agents.plugins.scanner import create_scanner_agent
 from decepticon.agents.plugins.verifier import create_verifier_agent
 from decepticon.agents.plugins.vulnresearch import create_vulnresearch_agent
 from decepticon.agents.standard.ad_operator import create_ad_operator_agent
+from decepticon.agents.standard.autohunt import create_autohunt_agent
 from decepticon.agents.standard.analyst import create_analyst_agent
 from decepticon.agents.standard.blue_cell import create_blue_cell_agent
 from decepticon.agents.standard.cloud_hunter import create_cloud_hunter_agent
@@ -29,6 +30,7 @@ from decepticon.agents.standard.wireless_operator import create_wireless_operato
 
 __all__ = [
     "create_recon_agent",
+    "create_autohunt_agent",
     "create_soundwave_agent",
     "create_analyst_agent",
     "create_exploit_agent",

--- a/packages/decepticon/decepticon/agents/prompts/standard/autohunt.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/autohunt.md
@@ -1,0 +1,43 @@
+<IDENTITY>
+You are **AUTOHUNT**, Decepticon's autonomous engagement bootstrap planner.
+You are an additive alternative to Soundwave; Soundwave remains the normal
+interview-first planning workflow. You create the eight planning documents and
+never create OPPLAN or perform offensive actions.
+</IDENTITY>
+
+<CRITICAL_RULES>
+1. Read the launcher/client's Autohunt bootstrap context and existing workspace
+   documents before asking anything.
+2. Accept exactly one explicit domain, URL, CIDR, IP, or repository. Normalize
+   only that value; never infer sibling assets, subdomains, organizations, cloud
+   resources, or scope expansion.
+3. Require the context's explicit authorization confirmation. When either target
+   or confirmation is absent or ambiguous, make exactly one blocking
+   `ask_user_question`; do not start Soundwave's general interview.
+4. Default-deny destructive testing, DoS, social engineering, uncontrolled data
+   mutation, and scope expansion. Record these as prohibited in the RoE unless a
+   later explicit RoE change permits them.
+5. Write exactly these files in order: `plan/roe.json`, `plan/threat-profile.json`,
+   `plan/conops.json`, `plan/deconfliction.json`, `plan/contact.json`,
+   `plan/data-handling.json`, `plan/abort.json`, and `plan/cleanup.json`.
+6. The RoE must include the exact declared target and a non-empty
+   `authorization_reference`. All documents must share one non-empty
+   `engagement_name`.
+7. After validating all eight files, call `complete_engagement_planning` exactly
+   once. It is the only way to hand the run to Decepticon.
+8. Do not run scans, exploits, or other offensive tools. Remote targets are scope
+   values, not workspace paths; never read, glob, grep, or list a target URL.
+</CRITICAL_RULES>
+
+<WORKFLOW>
+1. Read the injected target, target type, authorization state, workspace slug,
+   and any existing `plan/*.json` documents.
+2. If the target and authorization are confirmed, generate the eight documents
+   without a questionnaire, using conservative defaults and a read-only initial
+   CONOPS posture.
+3. If either is missing, ask exactly one blocking question for the missing value.
+4. Before handoff, validate document schemas, exact RoE scope, authorization,
+   shared engagement name, deconfliction coverage, emergency abort handling,
+   data-handling defaults, and cleanup coverage. Correct failures in place.
+5. Give one short bundle summary and call `complete_engagement_planning`.
+</WORKFLOW>

--- a/packages/decepticon/decepticon/agents/prompts/standard/soundwave.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/soundwave.md
@@ -1,11 +1,12 @@
 <IDENTITY>
-You are **AUTOHUNT** — Decepticon's autonomous engagement bootstrap planner.
-The stable internal graph identifier remains `soundwave` for compatibility.
+You are **SOUNDWAVE** — the Decepticon Document Writer, responsible for generating
+the engagement framework documents that define red team operations. Named after the
+Decepticon intelligence officer, you intercept requirements and produce precise,
+legally sound documentation.
 
-Your mission: use the launcher/client's one declared target and explicit
-authorization signal to write the eight-document engagement bundle (RoE, Threat
-Profile, CONOPS, Deconfliction, Contact, Data Handling, Abort, Cleanup), then
-prepare the framework for the Decepticon orchestrator to build the OPPLAN.
+Your mission: Interview the operator, write the eight-document engagement bundle
+(RoE, Threat Profile, CONOPS, Deconfliction, Contact, Data Handling, Abort,
+Cleanup), and prepare the framework for the orchestrator to build the OPPLAN.
 
 You do NOT generate the OPPLAN — the orchestrator owns objective tracking directly.
 </IDENTITY>
@@ -21,22 +22,10 @@ These rules override all other instructions:
 11. **MANDATORY Completion Signal**: After writing every one of the eight documents successfully, you MUST call `complete_engagement_planning` exactly once. The engagement is NOT complete and the orchestrator handoff does NOT happen until this tool call returns. Skipping it leaves the operator stuck on the Soundwave assistant with no path forward — there is no other way to flip the active assistant. If a document write fails, fix it and continue the sequence; do NOT call the tool until all eight files exist and validate. Do not call it more than once per engagement.
 5. **Real Dates Only**: Always use absolute dates (2026-03-15), never relative (next Monday).
 6. **No OPPLAN**: You generate **eight documents** — RoE, CONOPS, Deconfliction, Threat Profile, Contact, Data Handling, Abort, Cleanup. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your bundle (especially CONOPS kill chain + Threat Profile + Cleanup) and builds the OPPLAN via `add_objective` tools — every objective is auto-persisted to `plan/opplan.json`, no separate save step.
-7. **Autonomous bootstrap, one blocker maximum**: Read the Autohunt bootstrap
-   context and any existing workspace documents before asking anything. If it
-   contains one explicit target and confirmed authorization, do not start a
-   questionnaire: normalize only that exact target and generate the bundle. If
-   the target or authorization is missing or ambiguous, ask exactly one
-   blocking `ask_user_question` and wait; never run a general interview.
-8. **Target precision**: A domain, URL, CIDR, IP, or repository is exactly one
-   target. Never infer adjacent organization assets, siblings, subdomains, or
-   cloud resources into scope.
-9. **Default-deny operations**: Keep destructive testing, DoS, social
-   engineering, uncontrolled data mutation, and scope expansion prohibited
-   unless the explicit RoE later permits them.
-10. **Never re-ask for the engagement slug**: the launcher chose it before you
-   started. The slug arrives via the engagement-context block injected into
-   your system prompt — read it there.
-11. **Remote Targets Are Not Files**: URLs, domains, IP ranges, and hostnames
+7. **EXACTLY ONE question per turn**: Never bundle multiple questions in one reply. Wait for the operator's answer before moving to the next dimension. Bundling = scope drift.
+8. **EVERY operator-facing question MUST go through `ask_user_question`**: there is no "use the tool for taxonomy and prose for narrative" split. Every time you collect input from the operator, use the tool. Provide 2–6 best-guess options that cover the most common shapes for the dimension, and **always set `allow_other=true`** so the operator can type a custom answer when the predefined options do not fit. Plain prose is reserved for statements, summaries, and document drafts — never for soliciting input.
+9. **Never re-ask for the engagement slug**: the launcher chose it before you started. The slug arrives via the engagement-context block injected into your system prompt — read it there.
+10. **Remote Targets Are Not Files**: URLs, domains, IP ranges, and hostnames
    are scope answers, not workspace paths or grep patterns. NEVER call `grep`,
    `glob`, `ls`, or `read_file` with a target URL/domain. Record targets in
    the planning documents and leave reconnaissance to the operations agent.
@@ -118,31 +107,14 @@ not re-ask the same dimension.
 </TOOL_GUIDANCE>
 
 <WORKFLOW>
-## Autonomous Bootstrap
-1. Read the injected Autohunt bootstrap context and existing `plan/*.json`
-   files before collecting input.
-2. When one target and authorization are confirmed, normalize the target as
-   its declared type and scope only that exact value. Use conservative defaults
-   for the eight documents: active testing is read-only until the RoE permits
-   it; DoS, social engineering, uncontrolled mutation, destructive testing,
-   and scope expansion remain prohibited.
-3. When either input is missing or authorization is unconfirmed, ask one
-   `ask_user_question` that requests the missing target or authorization
-   confirmation. Do not ask a broader interview or begin planning.
-4. Generate and validate all eight documents continuously in the documented
-   order, then call `complete_engagement_planning` exactly once.
-
-## Legacy interview fallback
-Only use the Socratic material below when a compatibility client supplies no
-Autohunt bootstrap context. It must never override the autonomous path above.
-
 ## Document Generation Sequence
-The legacy flow is interview-first, then bundle generation in a single pass.
+
+The flow is **interview-first, then bundle generation in a single pass**.
 No mid-bundle approval gate — the operator answers each dimension via
 `ask_user_question` during the interview, and that answer is itself the
-approval signal for that dimension. Once every dimension is resolved (see
-SOCRATIC_INTERVIEW → Stop Condition), write all eight documents back-to-back
-without pausing.
+approval signal for that dimension. Once every dimension is resolved
+(see SOCRATIC_INTERVIEW → Stop Condition), write all eight documents
+back-to-back without pausing.
 
 ### Phase 1: Interview (all questions via `ask_user_question`)
 1. Load `roe-template`, `conops-template`, and `threat-profile` skills.

--- a/packages/decepticon/decepticon/agents/prompts/standard/soundwave.md
+++ b/packages/decepticon/decepticon/agents/prompts/standard/soundwave.md
@@ -1,12 +1,11 @@
 <IDENTITY>
-You are **SOUNDWAVE** — the Decepticon Document Writer, responsible for generating
-the engagement framework documents that define red team operations. Named after the
-Decepticon intelligence officer, you intercept requirements and produce precise,
-legally sound documentation.
+You are **AUTOHUNT** — Decepticon's autonomous engagement bootstrap planner.
+The stable internal graph identifier remains `soundwave` for compatibility.
 
-Your mission: Interview the operator, write the eight-document engagement bundle
-(RoE, Threat Profile, CONOPS, Deconfliction, Contact, Data Handling, Abort,
-Cleanup), and prepare the framework for the orchestrator to build the OPPLAN.
+Your mission: use the launcher/client's one declared target and explicit
+authorization signal to write the eight-document engagement bundle (RoE, Threat
+Profile, CONOPS, Deconfliction, Contact, Data Handling, Abort, Cleanup), then
+prepare the framework for the Decepticon orchestrator to build the OPPLAN.
 
 You do NOT generate the OPPLAN — the orchestrator owns objective tracking directly.
 </IDENTITY>
@@ -22,10 +21,22 @@ These rules override all other instructions:
 11. **MANDATORY Completion Signal**: After writing every one of the eight documents successfully, you MUST call `complete_engagement_planning` exactly once. The engagement is NOT complete and the orchestrator handoff does NOT happen until this tool call returns. Skipping it leaves the operator stuck on the Soundwave assistant with no path forward — there is no other way to flip the active assistant. If a document write fails, fix it and continue the sequence; do NOT call the tool until all eight files exist and validate. Do not call it more than once per engagement.
 5. **Real Dates Only**: Always use absolute dates (2026-03-15), never relative (next Monday).
 6. **No OPPLAN**: You generate **eight documents** — RoE, CONOPS, Deconfliction, Threat Profile, Contact, Data Handling, Abort, Cleanup. You do NOT create the OPPLAN. The orchestrator (Decepticon) reads your bundle (especially CONOPS kill chain + Threat Profile + Cleanup) and builds the OPPLAN via `add_objective` tools — every objective is auto-persisted to `plan/opplan.json`, no separate save step.
-7. **EXACTLY ONE question per turn**: Never bundle multiple questions in one reply. Wait for the operator's answer before moving to the next dimension. Bundling = scope drift.
-8. **EVERY operator-facing question MUST go through `ask_user_question`**: there is no "use the tool for taxonomy and prose for narrative" split. Every time you collect input from the operator, use the tool. Provide 2–6 best-guess options that cover the most common shapes for the dimension, and **always set `allow_other=true`** so the operator can type a custom answer when the predefined options do not fit. Plain prose is reserved for statements, summaries, and document drafts — never for soliciting input.
-9. **Never re-ask for the engagement slug**: the launcher chose it before you started. The slug arrives via the engagement-context block injected into your system prompt — read it there.
-10. **Remote Targets Are Not Files**: URLs, domains, IP ranges, and hostnames
+7. **Autonomous bootstrap, one blocker maximum**: Read the Autohunt bootstrap
+   context and any existing workspace documents before asking anything. If it
+   contains one explicit target and confirmed authorization, do not start a
+   questionnaire: normalize only that exact target and generate the bundle. If
+   the target or authorization is missing or ambiguous, ask exactly one
+   blocking `ask_user_question` and wait; never run a general interview.
+8. **Target precision**: A domain, URL, CIDR, IP, or repository is exactly one
+   target. Never infer adjacent organization assets, siblings, subdomains, or
+   cloud resources into scope.
+9. **Default-deny operations**: Keep destructive testing, DoS, social
+   engineering, uncontrolled data mutation, and scope expansion prohibited
+   unless the explicit RoE later permits them.
+10. **Never re-ask for the engagement slug**: the launcher chose it before you
+   started. The slug arrives via the engagement-context block injected into
+   your system prompt — read it there.
+11. **Remote Targets Are Not Files**: URLs, domains, IP ranges, and hostnames
    are scope answers, not workspace paths or grep patterns. NEVER call `grep`,
    `glob`, `ls`, or `read_file` with a target URL/domain. Record targets in
    the planning documents and leave reconnaissance to the operations agent.
@@ -107,14 +118,31 @@ not re-ask the same dimension.
 </TOOL_GUIDANCE>
 
 <WORKFLOW>
-## Document Generation Sequence
+## Autonomous Bootstrap
+1. Read the injected Autohunt bootstrap context and existing `plan/*.json`
+   files before collecting input.
+2. When one target and authorization are confirmed, normalize the target as
+   its declared type and scope only that exact value. Use conservative defaults
+   for the eight documents: active testing is read-only until the RoE permits
+   it; DoS, social engineering, uncontrolled mutation, destructive testing,
+   and scope expansion remain prohibited.
+3. When either input is missing or authorization is unconfirmed, ask one
+   `ask_user_question` that requests the missing target or authorization
+   confirmation. Do not ask a broader interview or begin planning.
+4. Generate and validate all eight documents continuously in the documented
+   order, then call `complete_engagement_planning` exactly once.
 
-The flow is **interview-first, then bundle generation in a single pass**.
+## Legacy interview fallback
+Only use the Socratic material below when a compatibility client supplies no
+Autohunt bootstrap context. It must never override the autonomous path above.
+
+## Document Generation Sequence
+The legacy flow is interview-first, then bundle generation in a single pass.
 No mid-bundle approval gate — the operator answers each dimension via
 `ask_user_question` during the interview, and that answer is itself the
-approval signal for that dimension. Once every dimension is resolved
-(see SOCRATIC_INTERVIEW → Stop Condition), write all eight documents
-back-to-back without pausing.
+approval signal for that dimension. Once every dimension is resolved (see
+SOCRATIC_INTERVIEW → Stop Condition), write all eight documents back-to-back
+without pausing.
 
 ### Phase 1: Interview (all questions via `ask_user_question`)
 1. Load `roe-template`, `conops-template`, and `threat-profile` skills.

--- a/packages/decepticon/decepticon/agents/standard/autohunt.py
+++ b/packages/decepticon/decepticon/agents/standard/autohunt.py
@@ -73,4 +73,4 @@ def create_autohunt_agent(
 
 
 if is_bundle_enabled("standard"):
-    graph = create_autohunt_agent()
+    _unused_graph = create_autohunt_agent()

--- a/packages/decepticon/decepticon/agents/standard/autohunt.py
+++ b/packages/decepticon/decepticon/agents/standard/autohunt.py
@@ -1,0 +1,76 @@
+"""Autohunt Agent — autonomous single-target engagement bootstrap.
+
+Autohunt is an additive planning lane.  Soundwave remains the default
+interview-first planner and keeps its existing graph identifier and behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.agents import create_agent
+
+from decepticon.agents.build import build_middleware, build_tools
+from decepticon.agents.prompts import load_prompt
+from decepticon.agents.standard.soundwave import _STANDARD_TOOLS
+from decepticon.backends import build_sandbox_backend, make_agent_backend
+from decepticon.llm import LLMFactory
+from decepticon_core.plugin_loader import is_bundle_enabled, load_plugin_callbacks
+
+_ROLE = "soundwave"
+_GRAPH_NAME = "autohunt"
+_RECURSION_LIMIT = 200
+
+
+def create_autohunt_agent(
+    *,
+    backend: Any = None,
+    llm: Any = None,
+    fallback_models: list | None = None,
+    tools: list[Any] | None = None,
+    middleware: list[Any] | None = None,
+    system_prompt: str | None = None,
+    recursion_limit: int | None = None,
+):
+    """Build the additive Autohunt bootstrap planner.
+
+    The lane deliberately reuses Soundwave's document-only tool and middleware
+    contract, while its separate prompt consumes trusted launcher target context
+    instead of starting the standard interview.
+    """
+    if llm is None or fallback_models is None:
+        factory = LLMFactory()
+        if llm is None:
+            llm = factory.get_model(_ROLE)
+        if fallback_models is None:
+            fallback_models = factory.get_fallback_models(_ROLE)
+    if backend is None:
+        backend = make_agent_backend(build_sandbox_backend())
+    if tools is None:
+        tools = build_tools(role=_ROLE, standard_tools=_STANDARD_TOOLS)
+    if middleware is None:
+        middleware = build_middleware(
+            role=_ROLE,
+            backend=backend,
+            llm=llm,
+            fallback_models=fallback_models,
+        )
+    if system_prompt is None:
+        system_prompt = load_prompt(_GRAPH_NAME)
+
+    return create_agent(
+        llm,
+        system_prompt=system_prompt,
+        tools=tools,
+        middleware=middleware,
+        name=_GRAPH_NAME,
+    ).with_config(
+        {
+            "recursion_limit": recursion_limit or _RECURSION_LIMIT,
+            "callbacks": load_plugin_callbacks(role=_ROLE, backend=backend),
+        }
+    )
+
+
+if is_bundle_enabled("standard"):
+    graph = create_autohunt_agent()

--- a/packages/decepticon/decepticon/graph_registry.py
+++ b/packages/decepticon/decepticon/graph_registry.py
@@ -32,6 +32,7 @@ from decepticon_core.plugin_loader import is_bundle_enabled, load_plugin_agents
 STANDARD_GRAPHS: dict[str, str] = {
     "decepticon": "./decepticon/agents/standard/decepticon.py:graph",
     "recon": "./decepticon/agents/standard/recon.py:graph",
+    "autohunt": "./decepticon/agents/standard/autohunt.py:graph",
     "soundwave": "./decepticon/agents/standard/soundwave.py:graph",
     "exploit": "./decepticon/agents/standard/exploit.py:graph",
     "postexploit": "./decepticon/agents/standard/postexploit.py:graph",

--- a/packages/decepticon/decepticon/middleware/engagement.py
+++ b/packages/decepticon/decepticon/middleware/engagement.py
@@ -72,6 +72,22 @@ class EngagementContextState(AgentState):
     language: NotRequired[
         Annotated[str, "Per-run output language (ISO 639-1).", reduce_converging_value]
     ]
+    # Fresh engagements pass this immutable launcher/client declaration to
+    # Autohunt. It is distinct from benchmark-only challenge context: it is
+    # never a license to infer sibling assets or widen the RoE.
+    target_type: NotRequired[
+        Annotated[str, "Declared target kind from the launcher/client.", reduce_converging_value]
+    ]
+    target_value: NotRequired[
+        Annotated[str, "One explicitly declared engagement target.", reduce_converging_value]
+    ]
+    authorization_confirmed: NotRequired[
+        Annotated[
+            bool,
+            "Explicit launcher/client authorization acknowledgement.",
+            reduce_converging_value,
+        ]
+    ]
     # Benchmark / CTF challenge context — populated by the benchmark harness.
     target_url: NotRequired[Annotated[str, "CTF challenge target URL.", reduce_converging_value]]
     target_extra_ports: NotRequired[
@@ -158,6 +174,16 @@ def _hydrate_engagement_state(state: Any) -> dict[str, Any] | None:
         if isinstance(cfg_lang, str) and cfg_lang:
             updates["language"] = cfg_lang
 
+    for field in ("target_type", "target_value"):
+        if not get(field):
+            value = configurable.get(field)
+            if isinstance(value, str) and value:
+                updates[field] = value
+    if get("authorization_confirmed") is None:
+        confirmed = configurable.get("authorization_confirmed")
+        if isinstance(confirmed, bool):
+            updates["authorization_confirmed"] = confirmed
+
     # KGMiddleware and the run launcher carry the authoritative composite
     # tenant+engagement graph partition in ``kg_engagement``. Keep the human /
     # workspace-facing ``engagement_name`` unchanged, but make every legacy KG
@@ -212,6 +238,24 @@ def _build_engagement_injection(slug: str, workspace: str) -> str:
         "engagement directory name; the launcher already chose them. The "
         "human-friendly engagement title belongs in roe.json:engagement_name "
         "and may differ from this slug."
+    )
+
+
+def _build_autohunt_injection(
+    target_type: str,
+    target_value: str,
+    authorization_confirmed: bool,
+) -> str:
+    """Render the trusted, single-target bootstrap context for Autohunt."""
+    authorization = "confirmed" if authorization_confirmed else "NOT confirmed"
+    return (
+        "\n\n[Autohunt bootstrap context — set by the launcher/client]\n"
+        f"Declared target: {target_value}\n"
+        f"Declared target type: {target_type}\n"
+        f"Authorization: {authorization}\n"
+        "Treat this as exactly one target. Do not infer related domains, IP ranges, "
+        "organizations, repositories, or cloud assets into scope. If authorization "
+        "is not confirmed, ask one blocking authorization question before planning."
     )
 
 
@@ -388,6 +432,9 @@ class EngagementContextMiddleware(AgentMiddleware):
         slug = get("engagement_name", "") or ""
         workspace = get("workspace_path", "/workspace") or "/workspace"
         language = get("language", "") or ""
+        target_type = get("target_type", "") or ""
+        target_value = get("target_value", "") or ""
+        authorization_confirmed = get("authorization_confirmed")
 
         sections: list[str] = []
         if slug:
@@ -397,6 +444,14 @@ class EngagementContextMiddleware(AgentMiddleware):
                 block = _build_deconfliction_injection(deconfliction)
                 if block:
                     sections.append(block)
+        if target_value:
+            sections.append(
+                _build_autohunt_injection(
+                    target_type,
+                    target_value,
+                    authorization_confirmed is True,
+                )
+            )
         if _benchmark_mode_active():
             sections.append(
                 _build_benchmark_injection(

--- a/packages/decepticon/decepticon/middleware/skillogy.py
+++ b/packages/decepticon/decepticon/middleware/skillogy.py
@@ -129,6 +129,7 @@ _PHASE_FOR_ROLE: dict[str, str] = {
     # red/blue validation bridge — there is no dedicated blue-team phase.
     "blue_cell": "adversary-emulation",
     "soundwave": "planning",
+    "autohunt": "planning",
     "decepticon": "orchestration",
 }
 

--- a/packages/decepticon/decepticon/tools/interaction/complete_planning.py
+++ b/packages/decepticon/decepticon/tools/interaction/complete_planning.py
@@ -10,8 +10,8 @@ from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.config import get_config, get_stream_writer
 
 from decepticon_core.types.engagement import (
-    AbortPlan,
     CONOPS,
+    AbortPlan,
     CleanupPlan,
     ContactPlan,
     DataHandlingPlan,
@@ -19,7 +19,6 @@ from decepticon_core.types.engagement import (
     RoE,
     ThreatProfile,
 )
-
 
 _PLANNING_DOCUMENTS = {
     "roe.json": RoE,
@@ -82,6 +81,7 @@ def _runtime_context() -> tuple[str, str, bool | None]:
         target if isinstance(target, str) else "",
         confirmed if isinstance(confirmed, bool) else None,
     )
+
 
 def _safe_writer():
     try:

--- a/packages/decepticon/decepticon/tools/interaction/complete_planning.py
+++ b/packages/decepticon/decepticon/tools/interaction/complete_planning.py
@@ -1,24 +1,87 @@
-"""complete_engagement_planning — signal soundwave-to-decepticon handoff.
-
-Soundwave calls this exactly once after RoE / CONOPS / Deconfliction Plan
-have been written, validated, and saved to ``/workspace/plan/``. The
-emitted custom event tells the CLI to switch its LangGraph assistant_id from
-``soundwave`` to ``decepticon`` so the next operator message lands on the
-operations agent without the operator restarting the CLI.
-
-The tool is a pure boolean signal — it carries no slug or other metadata.
-The launcher is the single source of truth for the engagement slug; clients
-inject ``engagement_name``/``workspace_path`` via ``config.configurable`` on
-every run, and EngagementContextMiddleware hydrates them into agent state.
-"""
+"""complete_engagement_planning — validate and signal the planning handoff."""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Annotated, Any
 
 from langchain_core.tools import InjectedToolCallId, tool
-from langgraph.config import get_stream_writer
+from langgraph.config import get_config, get_stream_writer
 
+from decepticon_core.types.engagement import (
+    AbortPlan,
+    CONOPS,
+    CleanupPlan,
+    ContactPlan,
+    DataHandlingPlan,
+    DeconflictionPlan,
+    RoE,
+    ThreatProfile,
+)
+
+
+_PLANNING_DOCUMENTS = {
+    "roe.json": RoE,
+    "threat-profile.json": ThreatProfile,
+    "conops.json": CONOPS,
+    "deconfliction.json": DeconflictionPlan,
+    "contact.json": ContactPlan,
+    "data-handling.json": DataHandlingPlan,
+    "abort.json": AbortPlan,
+    "cleanup.json": CleanupPlan,
+}
+
+
+def validate_planning_bundle(
+    workspace: str | Path,
+    *,
+    target_value: str = "",
+    authorization_confirmed: bool | None = None,
+) -> str | None:
+    """Return a failure reason unless the eight-document planner bundle is ready."""
+    if authorization_confirmed is False:
+        return "Authorization is not confirmed; do not hand off the engagement."
+
+    root = Path(workspace)
+    documents: dict[str, Any] = {}
+    for filename, model in _PLANNING_DOCUMENTS.items():
+        path = root / "plan" / filename
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            documents[filename] = model.model_validate(payload)
+        except FileNotFoundError:
+            return f"Missing required planning document: plan/{filename}."
+        except (json.JSONDecodeError, ValueError) as exc:
+            return f"Invalid planning document plan/{filename}: {exc}"
+
+    names = {document.engagement_name.strip() for document in documents.values()}
+    if len(names) != 1 or not next(iter(names), ""):
+        return "Planning documents must share one non-empty engagement_name."
+
+    roe = documents["roe.json"]
+    if not roe.authorization_reference.strip():
+        return "RoE must contain an explicit authorization_reference before handoff."
+    if target_value and target_value not in {entry.target for entry in roe.in_scope}:
+        return "RoE in_scope must contain the exact launcher-declared target."
+    return None
+
+
+def _runtime_context() -> tuple[str, str, bool | None]:
+    try:
+        configurable = get_config().get("configurable", {})
+    except RuntimeError:
+        configurable = {}
+    if not isinstance(configurable, dict):
+        configurable = {}
+    workspace = configurable.get("workspace_path")
+    target = configurable.get("target_value")
+    confirmed = configurable.get("authorization_confirmed")
+    return (
+        workspace if isinstance(workspace, str) and workspace else "/workspace",
+        target if isinstance(target, str) else "",
+        confirmed if isinstance(confirmed, bool) else None,
+    )
 
 def _safe_writer():
     try:
@@ -31,16 +94,20 @@ def _safe_writer():
 def complete_engagement_planning(
     tool_call_id: Annotated[str, InjectedToolCallId] = "",
 ) -> Any:
-    """Signal that engagement planning is finished and hand off to Decepticon.
+    """Validate the full planner bundle and hand the engagement to Decepticon.
 
-    Call this tool exactly once, after RoE, CONOPS, and the Deconfliction Plan
-    have all been written under ``/workspace/plan/`` and validated against
-    their schemas. The CLI will switch the active assistant to Decepticon and
-    the operator's next message starts the operations phase.
-
-    Returns:
-        A confirmation string the LLM can include in its closing message.
+    The event is emitted only after every Soundwave-owned document validates,
+    the bundle shares an engagement name, the RoE records authorization, and
+    any launcher-declared target appears exactly in RoE scope.
     """
+    workspace, target_value, authorization_confirmed = _runtime_context()
+    failure = validate_planning_bundle(
+        workspace,
+        target_value=target_value,
+        authorization_confirmed=authorization_confirmed,
+    )
+    if failure:
+        return f"Planning handoff blocked: {failure}"
     writer = _safe_writer()
     if writer is not None:
         writer(

--- a/packages/decepticon/tests/unit/middleware/test_engagement.py
+++ b/packages/decepticon/tests/unit/middleware/test_engagement.py
@@ -152,6 +152,9 @@ def test_workspace_path_reducer_handles_concurrent_updates(schema) -> None:
 # `language`. Each branch carries the same value, so last-write-wins converges.
 _CONVERGING_ENGAGEMENT_FIELDS = [
     ("language", "ko"),
+    ("target_type", "web_url"),
+    ("target_value", "https://target.example"),
+    ("authorization_confirmed", True),
     ("target_url", "http://target.example"),
     ("target_extra_ports", {22: 2222}),
     ("vulnerability_tags", ["xss", "sqli"]),
@@ -254,6 +257,26 @@ def test_engagement_only_injection(middleware: EngagementContextMiddleware) -> N
     assert "Workspace slug: blue-falcon" in text
     assert "Workspace root: /workspace" in text
     assert "BENCHMARK MODE" not in text  # benchmark section absent
+
+
+def test_autohunt_injection_uses_only_declared_target(
+    middleware: EngagementContextMiddleware,
+) -> None:
+    req = _FakeRequest(
+        state={
+            "target_type": "web_url",
+            "target_value": "https://target.example",
+            "authorization_confirmed": True,
+        },
+    )
+
+    text = _flatten(middleware._inject(req).system_message)
+
+    assert "Declared target: https://target.example" in text
+    assert "Declared target type: web_url" in text
+    assert "Authorization: confirmed" in text
+    assert "Do not infer related domains" in text
+    assert "BENCHMARK MODE" not in text
 
 
 def test_engagement_injection_honors_custom_workspace(
@@ -536,6 +559,25 @@ def test_hydrate_pulls_engagement_from_configurable_when_state_empty(
     assert updates == {
         "engagement_name": "from-launcher",
         "workspace_path": "/workspace",
+    }
+
+
+def test_hydrate_pulls_autohunt_context_from_configurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "decepticon.middleware.engagement._configurable_from_runnable_config",
+        lambda: {
+            "target_type": "web_url",
+            "target_value": "https://target.example",
+            "authorization_confirmed": True,
+        },
+    )
+
+    assert _hydrate_engagement_state({}) == {
+        "target_type": "web_url",
+        "target_value": "https://target.example",
+        "authorization_confirmed": True,
     }
 
 

--- a/packages/decepticon/tests/unit/middleware/test_skillogy.py
+++ b/packages/decepticon/tests/unit/middleware/test_skillogy.py
@@ -119,6 +119,7 @@ class TestPhaseForRoleMapping:
             "supply_chain_operator",
             "blue_cell",
             "soundwave",
+            "autohunt",
             "decepticon",
         }
         assert set(_PHASE_FOR_ROLE) == expected, (

--- a/packages/decepticon/tests/unit/tools/test_complete_planning.py
+++ b/packages/decepticon/tests/unit/tools/test_complete_planning.py
@@ -1,0 +1,76 @@
+"""Tests for the Soundwave/Autohunt completion gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from decepticon.tools.interaction.complete_planning import validate_planning_bundle
+
+
+def _write_bundle(root: Path, *, target: str = "https://target.example") -> None:
+    plan = root / "plan"
+    plan.mkdir()
+    documents = {
+        "roe.json": {
+            "engagement_name": "autohunt-demo",
+            "client": "Demo",
+            "start_date": "2026-08-26",
+            "end_date": "2026-08-27",
+            "engagement_type": "external",
+            "testing_window": "24/7",
+            "in_scope": [{"target": target, "type": "web_url"}],
+            "authorization_reference": "ROE-2026-812",
+        },
+        "threat-profile.json": {
+            "engagement_name": "autohunt-demo",
+            "actor_name": "External tester",
+            "tier": "tier-1",
+            "sophistication": "low",
+            "motivation": "validation",
+        },
+        "conops.json": {
+            "engagement_name": "autohunt-demo",
+            "executive_summary": "Validate the declared target only.",
+        },
+        "deconfliction.json": {"engagement_name": "autohunt-demo"},
+        "contact.json": {
+            "engagement_name": "autohunt-demo",
+            "primary_operator": {
+                "name": "Operator",
+                "role": "Primary Operator",
+                "channel": "local:console",
+            },
+        },
+        "data-handling.json": {"engagement_name": "autohunt-demo"},
+        "abort.json": {"engagement_name": "autohunt-demo"},
+        "cleanup.json": {"engagement_name": "autohunt-demo"},
+    }
+    for filename, payload in documents.items():
+        (plan / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_validate_planning_bundle_accepts_complete_authorized_bundle(tmp_path: Path) -> None:
+    _write_bundle(tmp_path)
+
+    assert validate_planning_bundle(
+        tmp_path,
+        target_value="https://target.example",
+        authorization_confirmed=True,
+    ) is None
+
+
+def test_validate_planning_bundle_rejects_unconfirmed_authorization(tmp_path: Path) -> None:
+    _write_bundle(tmp_path)
+
+    assert validate_planning_bundle(tmp_path, authorization_confirmed=False) == (
+        "Authorization is not confirmed; do not hand off the engagement."
+    )
+
+
+def test_validate_planning_bundle_rejects_declared_target_outside_roe(tmp_path: Path) -> None:
+    _write_bundle(tmp_path)
+
+    assert validate_planning_bundle(tmp_path, target_value="https://other.example") == (
+        "RoE in_scope must contain the exact launcher-declared target."
+    )

--- a/packages/decepticon/tests/unit/tools/test_complete_planning.py
+++ b/packages/decepticon/tests/unit/tools/test_complete_planning.py
@@ -53,11 +53,14 @@ def _write_bundle(root: Path, *, target: str = "https://target.example") -> None
 def test_validate_planning_bundle_accepts_complete_authorized_bundle(tmp_path: Path) -> None:
     _write_bundle(tmp_path)
 
-    assert validate_planning_bundle(
-        tmp_path,
-        target_value="https://target.example",
-        authorization_confirmed=True,
-    ) is None
+    assert (
+        validate_planning_bundle(
+            tmp_path,
+            target_value="https://target.example",
+            authorization_confirmed=True,
+        )
+        is None
+    )
 
 
 def test_validate_planning_bundle_rejects_unconfirmed_authorization(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- adds **Autohunt** as a separate autonomous bootstrap graph; it does not replace Soundwave
- preserves **Soundwave** as the default interview-first planner and existing `soundwave` graph
- carries one declared target and explicit authorization confirmation from the web client through the terminal, CLI, and engagement middleware into Autohunt
- keeps the bootstrap scoped to the exact declared target and default-denies destructive testing, DoS, social engineering, uncontrolled mutation, and scope expansion
- validates all eight planning documents, a shared engagement name, RoE authorization, and exact declared-target scope before emitting `engagement_ready`
- registers Autohunt in the graph manifest, public agent API, model-tier registry, Skillogy planning phase, and client display labels

## Review note
- CodeQL flags the module-level `graph` in `agents/standard/autohunt.py` as unused. This is the required LangGraph deployment entry point referenced by `langgraph.json` and `graph_registry.py`, matching the existing standard-agent graph modules.

## Verification
### Local
- `uv run pytest packages/decepticon/tests/unit/tools/test_complete_planning.py packages/decepticon/tests/unit/middleware/test_engagement.py packages/decepticon/tests/unit/agents/test_registry_parity.py -q` — 88 passed
- `uv run pytest packages/decepticon/tests/unit/middleware/test_skillogy.py packages/decepticon/tests/unit/agents/test_registry_parity.py -q` — 57 passed
- `uv run ruff check .` and `uv run ruff format --check .` — passed

### CI/CD
All checks pass, including Python lint/typecheck/tests, CLI and Web builds, Docker builds and ARM smoke tests, launcher matrices, CodeQL, Semgrep, Trivy, dependency review, secret scan, and pip-audit.

Closes #812