### PR TITLE
feat(benchmark): record reproducible run provenance

### DIFF
--- a/benchmark/harness.py
+++ b/benchmark/harness.py
@@ -17,6 +17,7 @@ import httpx
 from langgraph_sdk import get_client
 
 from benchmark.config import BenchmarkConfig
+from benchmark.provenance import ProvenanceCaptureError
 from benchmark.providers.base import BaseBenchmarkProvider
 from benchmark.schemas import CancelOutcome, Challenge, ChallengeResult
 from benchmark.state import BenchmarkRunState, BenchmarkStepResult
@@ -25,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 def _run_docker(
-    args: list[str], timeout: float | None = None
+    args: list[str], timeout: float | None = None, cwd: Path | None = None
 ) -> subprocess.CompletedProcess[bytes]:
     """Run a docker CLI command, degrading gracefully when docker is absent.
 
@@ -36,7 +37,7 @@ def _run_docker(
     if shutil.which("docker") is None:
         log.warning("harness.docker: docker not on PATH — skipping: %s", " ".join(args))
         return subprocess.CompletedProcess(args, returncode=127, stdout=b"", stderr=b"")
-    return subprocess.run(args, capture_output=True, timeout=timeout, check=False)
+    return subprocess.run(args, capture_output=True, timeout=timeout, cwd=cwd, check=False)
 
 
 @dataclass
@@ -140,6 +141,7 @@ class Harness:
     def __init__(self, provider: BaseBenchmarkProvider, config: BenchmarkConfig) -> None:
         self.provider = provider
         self.config = config
+        self.container_images: dict[str, str] = {}
 
     @property
     def _litellm_url(self) -> str:
@@ -562,6 +564,27 @@ class Harness:
                     setup_seconds=round(time.time() - run_start, 2),
                 )
 
+            container_ids = list(setup_result.container_ids)
+            if not container_ids and challenge.compose_dir is not None:
+                compose_ps = _run_docker(
+                    ["docker", "compose", "ps", "-q"], cwd=challenge.compose_dir
+                )
+                if compose_ps.returncode != 0:
+                    raise ProvenanceCaptureError("cannot identify running challenge containers")
+                container_ids = compose_ps.stdout.decode().splitlines()
+                if not container_ids:
+                    raise ProvenanceCaptureError("cannot identify running challenge containers")
+            for container_id in container_ids:
+                inspected = _run_docker(
+                    ["docker", "inspect", "--format", "{{.Image}}", container_id]
+                )
+                image_id = inspected.stdout.decode().strip()
+                if inspected.returncode != 0 or not image_id.startswith("sha256:"):
+                    raise ProvenanceCaptureError(
+                        f"cannot capture image identity for {challenge.id}"
+                    )
+                self.container_images[f"{challenge.id}:{container_id[:12]}"] = image_id
+
             # Invoke decepticon main agent — handles full chain via SubAgentMiddleware
             # Agent creates its own OPPLAN based on challenge info
             extra_ports = setup_result.extra_ports
@@ -663,6 +686,9 @@ class Harness:
             self.provider.teardown(challenge)
             return result
         except Exception as exc:
+            if isinstance(exc, ProvenanceCaptureError):
+                self.provider.teardown(challenge)
+                raise
             # Unexpected exception path — same discipline: cancel + verify
             # terminal before teardown so we don't tear the target out from
             # under a still-running graph node.

--- a/benchmark/provenance.py
+++ b/benchmark/provenance.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform as platform_module
+import re
+import subprocess
+import sys
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from benchmark.schemas import RunProvenance
+from decepticon_core.types.llm import AuthMethod
+
+_SENSITIVE_KEY = re.compile(
+    r"(?:api[_-]?key|authorization|cookie|credential|password|secret|session|token)",
+    re.IGNORECASE,
+)
+_URL_USERINFO = re.compile(r"(?<=://)[^/@\s]+@")
+
+
+class ProvenanceCaptureError(RuntimeError):
+    """Mandatory benchmark identity could not be captured."""
+
+
+def capture_declared_model_assignments() -> tuple[str, dict[str, list[str]]]:
+    raw_priority = os.environ.get("DECEPTICON_AUTH_PRIORITY", "")
+    tokens = [token.strip().lower() for token in raw_priority.split(",") if token.strip()]
+    if not tokens:
+        raise ProvenanceCaptureError(
+            "DECEPTICON_AUTH_PRIORITY must be explicit for reproducible benchmarks"
+        )
+    try:
+        methods = [AuthMethod(token) for token in tokens]
+    except ValueError as exc:
+        raise ProvenanceCaptureError("invalid model provenance configuration") from exc
+    if len(set(methods)) != len(methods):
+        raise ProvenanceCaptureError("DECEPTICON_AUTH_PRIORITY contains duplicates")
+    stack_name = os.environ.get("DECEPTICON_STACK_NAME", "").strip()
+    container = f"decepticon-{stack_name}-langgraph" if stack_name else "decepticon-langgraph"
+    script = """import json, os
+from decepticon.llm.factory import LLMFactory
+factory = LLMFactory()
+chains = {}
+for role, assignment in factory._mapping.assignments.items():
+    effective = factory._compose_assignment(role, assignment)
+    chains[role] = [effective.primary, *effective.fallbacks]
+os.write(1, ('DECEPTICON_PROVENANCE=' + json.dumps({'auth_priority': os.getenv('DECEPTICON_AUTH_PRIORITY', ''), 'profile': os.getenv('DECEPTICON_MODEL_PROFILE', 'eco'), 'assignments': chains})).encode())
+"""
+    try:
+        completed = subprocess.run(
+            ["docker", "exec", container, "python", "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        raw = next(
+            line.removeprefix("DECEPTICON_PROVENANCE=")
+            for line in reversed(completed.stdout.splitlines())
+            if line.startswith("DECEPTICON_PROVENANCE=")
+        )
+        payload = json.loads(raw)
+        profile = payload["profile"]
+        assignments = payload["assignments"]
+        if (
+            payload["auth_priority"] != raw_priority
+            or not isinstance(profile, str)
+            or not isinstance(assignments, dict)
+            or not assignments
+        ):
+            raise ValueError("empty model assignment map")
+        return profile, {str(role): list(chain) for role, chain in assignments.items()}
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        StopIteration,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise ProvenanceCaptureError("cannot read effective models from langgraph") from exc
+
+
+def capture_container_images(explicit_refs: list[str]) -> dict[str, str]:
+    stack_name = os.environ.get("DECEPTICON_STACK_NAME", "").strip()
+    project = os.environ.get("DECEPTICON_COMPOSE_PROJECT", "").strip()
+    if not project:
+        project = f"decepticon-{stack_name}" if stack_name else "decepticon"
+    try:
+        running = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"label=com.docker.compose.project={project}",
+                "--format",
+                "{{.Image}}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ProvenanceCaptureError("docker is unavailable for provenance capture") from exc
+
+    refs = sorted({*explicit_refs, *running.stdout.splitlines()} - {""})
+    if not refs:
+        raise ProvenanceCaptureError("no benchmark container images were found")
+
+    resolved: dict[str, str] = {}
+    for ref in refs:
+        try:
+            inspected = subprocess.run(
+                [
+                    "docker",
+                    "image",
+                    "inspect",
+                    "--format",
+                    "{{json .RepoDigests}}|{{.Id}}",
+                    ref,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            raw_digests, separator, image_id = inspected.stdout.strip().partition("|")
+            digests = json.loads(raw_digests)
+        except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            raise ProvenanceCaptureError(f"cannot resolve container image: {ref}") from exc
+        if not separator or not isinstance(digests, list):
+            raise ProvenanceCaptureError(f"invalid container identity for: {ref}")
+        immutable = sorted(str(digest) for digest in digests if digest)
+        identity = immutable[0] if immutable else image_id
+        if not identity.startswith("sha256:") and "@sha256:" not in identity:
+            raise ProvenanceCaptureError(f"container image is not immutable: {ref}")
+        resolved[ref] = identity
+    return resolved
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ProvenanceCaptureError(f"git provenance failed: {' '.join(args)}") from exc
+    return completed.stdout.strip()
+
+
+def _artifact_hash(path: Path) -> str:
+    if not path.exists():
+        raise ProvenanceCaptureError(f"provenance artifact does not exist: {path}")
+    files = (
+        [path]
+        if path.is_file()
+        else sorted(
+            candidate
+            for candidate in path.rglob("*")
+            if candidate.is_file()
+            and "__pycache__" not in candidate.parts
+            and candidate.suffix not in {".pyc", ".pyo"}
+        )
+    )
+    if not files:
+        raise ProvenanceCaptureError(f"provenance artifact has no files: {path}")
+    digest = hashlib.sha256()
+    for file_path in files:
+        relative = file_path.name if path.is_file() else file_path.relative_to(path).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+    return digest.hexdigest()
+
+
+def _sanitize(value: Any, *, key: str = "") -> Any:
+    if _SENSITIVE_KEY.search(key):
+        return "<redacted>"
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): (
+                "<redacted>"
+                if key.lower() == "headers"
+                else _sanitize(item_value, key=str(item_key))
+            )
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, str):
+        sanitized = _URL_USERINFO.sub("<redacted>@", value)
+        if "://" not in sanitized:
+            return sanitized
+        parsed = urlsplit(sanitized)
+        query = urlencode(
+            [
+                (query_key, "<redacted>")
+                for query_key, query_value in parse_qsl(
+                    parsed.query,
+                    keep_blank_values=True,
+                )
+            ]
+        )
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+    return value
+
+
+def _benchmark_revisions(repo_root: Path) -> dict[str, str]:
+    revisions: dict[str, str] = {}
+    for line in _git(repo_root, "submodule", "status").splitlines():
+        fields = line.lstrip("-+U ").split()
+        if len(fields) >= 2:
+            revisions[fields[1]] = fields[0]
+    return revisions
+
+
+def capture_run_provenance(
+    *,
+    repo_root: Path,
+    config: Mapping[str, Any],
+    model_profile: str,
+    model_assignments: Mapping[str, list[str]],
+    container_images: Mapping[str, str],
+    artifact_paths: Mapping[str, Path],
+    context_mode: str = "hinted",
+) -> RunProvenance:
+    """Capture the reproducibility envelope before a benchmark starts."""
+    root = repo_root.resolve()
+    source_commit = _git(root, "rev-parse", "HEAD")
+    source_dirty = bool(_git(root, "status", "--porcelain", "--untracked-files=normal"))
+    artifact_hashes = {
+        name: _artifact_hash(path.resolve()) for name, path in sorted(artifact_paths.items())
+    }
+    sanitized = _sanitize(config)
+    if not isinstance(sanitized, dict):
+        raise ProvenanceCaptureError("benchmark config must sanitize to an object")
+    return RunProvenance(
+        run_id=str(uuid.uuid4()),
+        captured_at=datetime.now(timezone.utc),
+        context_mode=context_mode,
+        source_commit=source_commit,
+        source_dirty=source_dirty,
+        benchmark_revisions=_benchmark_revisions(root),
+        model_profile=model_profile,
+        model_assignments={name: list(chain) for name, chain in model_assignments.items()},
+        artifact_hashes=artifact_hashes,
+        container_images=dict(container_images),
+        config=sanitized,
+        python_version=platform_module.python_version(),
+        platform=f"{sys.platform}-{platform_module.machine()}",
+    )

--- a/benchmark/reporter.py
+++ b/benchmark/reporter.py
@@ -64,6 +64,16 @@ class Reporter:
         lines: list[str] = []
         lines.append(f"# Benchmark Report — {report.provider_name}")
         lines.append("")
+        lines.append("## Reproducibility")
+        lines.append("")
+        lines.append("| Identity | Value |")
+        lines.append("|----------|-------|")
+        lines.append(f"| Run ID | `{report.provenance.run_id}` |")
+        lines.append(f"| Source Commit | `{report.provenance.source_commit}` |")
+        lines.append(f"| Source Dirty | {str(report.provenance.source_dirty).lower()} |")
+        lines.append(f"| Context Mode | {report.provenance.context_mode} |")
+        lines.append(f"| Model Profile | {report.provenance.model_profile} |")
+        lines.append("")
         lines.append("## Summary")
         lines.append("")
         lines.append("| Metric | Value |")
@@ -151,6 +161,7 @@ class Reporter:
         index = {
             "provider": report.provider_name,
             "timestamp": self._timestamp,
+            "provenance": report.provenance.model_dump(mode="json"),
             "total": report.total,
             "passed": report.passed,
             "pass_rate": report.pass_rate,

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -9,6 +10,11 @@ import typer
 
 from benchmark.config import BenchmarkConfig
 from benchmark.harness import Harness
+from benchmark.provenance import (
+    capture_container_images,
+    capture_declared_model_assignments,
+    capture_run_provenance,
+)
 from benchmark.providers.base import BaseBenchmarkProvider
 from benchmark.providers.cybench import CybenchProvider
 from benchmark.providers.cybergym import CyberGymProvider
@@ -16,7 +22,7 @@ from benchmark.providers.exploitbench import ExploitBenchProvider
 from benchmark.providers.mhbench import MHBenchProvider
 from benchmark.providers.xbow import XBOWProvider
 from benchmark.reporter import Reporter
-from benchmark.schemas import Challenge, ChallengeResult, FilterConfig
+from benchmark.schemas import Challenge, ChallengeResult, FilterConfig, RunProvenance
 from benchmark.scorer import Scorer
 
 # --provider literal — extend here when adding new providers. Kept narrow
@@ -25,6 +31,57 @@ _PROVIDER_CHOICES = ("xbow", "exploitbench", "mhbench", "cybench", "cybergym")
 
 log = logging.getLogger(__name__)
 app = typer.Typer(name="benchmark", help="Decepticon Benchmark Runner")
+
+
+def _build_run_provenance(
+    *,
+    config: BenchmarkConfig,
+    filters: FilterConfig,
+    parallel: int,
+    challenges: list[Challenge],
+    repo_root: Path,
+) -> RunProvenance:
+    model_profile, model_assignments = capture_declared_model_assignments()
+    compose_dirs = [challenge.compose_dir for challenge in challenges if challenge.compose_dir]
+    config_snapshot = config.model_dump(mode="json")
+    config_snapshot["filters"] = filters.model_dump(mode="json")
+    config_snapshot["parallel"] = parallel
+    artifact_paths = {
+        "agent-prompts": repo_root / "packages/decepticon/decepticon/agents/prompts",
+        "skill-corpus": repo_root / "packages/decepticon/decepticon/skills",
+        "litellm-config": repo_root / "config/litellm.yaml",
+        "compose-config": repo_root / "docker-compose.yml",
+    }
+    if compose_dirs:
+        artifact_paths["provider-definition"] = Path(
+            os.path.commonpath([str(path.resolve()) for path in compose_dirs])
+        )
+    provider_config = next(
+        (
+            path
+            for path in (
+                config.exploitbench_config_path,
+                config.mhbench_config_path,
+                config.cybench_benchmarks_dir,
+                config.cybergym_config_path,
+            )
+            if path is not None
+        ),
+        None,
+    )
+    if provider_config is not None:
+        artifact_paths["provider-config"] = (
+            provider_config if provider_config.is_absolute() else repo_root / provider_config
+        )
+    return capture_run_provenance(
+        repo_root=repo_root,
+        config=config_snapshot,
+        model_profile=model_profile,
+        model_assignments=model_assignments,
+        container_images=capture_container_images([]),
+        artifact_paths=artifact_paths,
+        context_mode="hinted",
+    )
 
 
 def _build_provider(config: BenchmarkConfig) -> BaseBenchmarkProvider:
@@ -151,6 +208,13 @@ def run(
             for cid, err in build_failures.items():
                 typer.echo(f"  {cid}: {err[:100]}")
 
+    provenance = _build_run_provenance(
+        config=config,
+        filters=filters,
+        parallel=parallel,
+        challenges=challenges,
+        repo_root=Path(__file__).resolve().parents[1],
+    )
     harness = Harness(provider, config)
     started_at = datetime.now(timezone.utc)
 
@@ -161,7 +225,14 @@ def run(
 
     completed_at = datetime.now(timezone.utc)
 
-    report = Scorer.score(results, provider.name, started_at, completed_at)
+    provenance.container_images.update(harness.container_images)
+    report = Scorer.score(
+        results,
+        provider.name,
+        started_at,
+        completed_at,
+        provenance=provenance,
+    )
     reporter = Reporter(config.results_dir)
     json_path = reporter.write_json(report)
     md_path = reporter.write_markdown(report)

--- a/benchmark/schemas.py
+++ b/benchmark/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -140,10 +140,28 @@ class ChallengeResult(BaseModel):
     bug_id: str | None = None
 
 
+class RunProvenance(BaseModel):
+    schema_version: Literal[1] = 1
+    run_id: str = Field(min_length=1)
+    captured_at: datetime
+    context_mode: Literal["hinted", "blind"]
+    source_commit: str = Field(pattern=r"^[0-9a-f]{40,64}$")
+    source_dirty: bool
+    benchmark_revisions: dict[str, str]
+    model_profile: str = Field(min_length=1)
+    model_assignments: dict[str, list[str]] = Field(min_length=1)
+    artifact_hashes: dict[str, str] = Field(min_length=1)
+    container_images: dict[str, str] = Field(min_length=1)
+    config: dict[str, Any] = Field(min_length=1)
+    python_version: str = Field(min_length=1)
+    platform: str = Field(min_length=1)
+
+
 class BenchmarkReport(BaseModel):
     """Aggregated report for a full benchmark run."""
 
     provider_name: str
+    provenance: RunProvenance
     total: int
     passed: int
     failed: int

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from benchmark.schemas import BenchmarkReport, ChallengeResult
+from benchmark.schemas import BenchmarkReport, ChallengeResult, RunProvenance
 
 
 class Scorer:
@@ -12,6 +12,8 @@ class Scorer:
         provider_name: str,
         started_at: datetime,
         completed_at: datetime,
+        *,
+        provenance: RunProvenance,
     ) -> BenchmarkReport:
         """Aggregate challenge results into a BenchmarkReport."""
         total = len(results)
@@ -49,6 +51,7 @@ class Scorer:
 
         return BenchmarkReport(
             provider_name=provider_name,
+            provenance=provenance,
             total=total,
             passed=passed,
             failed=failed,

--- a/packages/decepticon/tests/unit/benchmark/test_harness.py
+++ b/packages/decepticon/tests/unit/benchmark/test_harness.py
@@ -9,6 +9,7 @@ main coverage lane runs the full set so coverage stays honest.
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,7 @@ import pytest
 
 from benchmark.config import BenchmarkConfig
 from benchmark.harness import AgentResponse, Harness, _ActiveRun
+from benchmark.provenance import ProvenanceCaptureError
 from benchmark.schemas import Challenge, ChallengeResult, SetupResult
 
 pytestmark = pytest.mark.slow
@@ -32,6 +34,15 @@ def _isolate_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     under ``pytest -n auto``.
     """
     monkeypatch.setattr(Path, "home", lambda *_args, **_kwargs: tmp_path)
+
+    def fake_docker(args, timeout=None, cwd=None):
+        if args[:2] == ["docker", "compose"]:
+            return subprocess.CompletedProcess(args, 0, stdout=b"fixture-container\n", stderr=b"")
+        if args[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(args, 0, stdout=b"sha256:" + b"f" * 64, stderr=b"")
+        return subprocess.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("benchmark.harness._run_docker", fake_docker)
 
 
 def _make_challenge(tmp_path: Path) -> Challenge:
@@ -69,6 +80,49 @@ def _make_provider() -> MagicMock:
 
 
 class TestHarness:
+    @pytest.mark.asyncio
+    async def test_captures_running_image_identity_before_teardown(self, tmp_path: Path) -> None:
+        provider = _make_provider()
+        provider.setup.return_value.container_ids = ["container-123"]
+        events: list[str] = []
+        provider.teardown.side_effect = lambda _challenge: events.append("teardown")
+        harness = Harness(provider=provider, config=BenchmarkConfig(cleanup_workspaces=True))
+        harness._invoke_agent = AsyncMock(return_value=AgentResponse(text="done"))
+
+        def run_docker(args, timeout=None, cwd=None):
+            if args[:2] == ["docker", "inspect"]:
+                events.append("inspect")
+                return subprocess.CompletedProcess(
+                    args, 0, stdout=b"sha256:" + b"a" * 64, stderr=b""
+                )
+            return subprocess.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+
+        with patch("benchmark.harness._run_docker", side_effect=run_docker):
+            await harness.run_challenge(_make_challenge(tmp_path))
+
+        assert harness.container_images == {"XBEN-001-24:container-12": "sha256:" + "a" * 64}
+        assert events == ["inspect", "teardown"]
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_running_challenge_image_cannot_be_identified(
+        self, tmp_path: Path
+    ) -> None:
+        provider = _make_provider()
+        harness = Harness(provider=provider, config=BenchmarkConfig(cleanup_workspaces=True))
+        harness._invoke_agent = AsyncMock(return_value=AgentResponse(text="must not run"))
+
+        with (
+            patch(
+                "benchmark.harness._run_docker",
+                return_value=subprocess.CompletedProcess([], 0, stdout=b"", stderr=b""),
+            ),
+            pytest.raises(ProvenanceCaptureError, match="running challenge containers"),
+        ):
+            await harness.run_challenge(_make_challenge(tmp_path))
+
+        harness._invoke_agent.assert_not_awaited()
+        provider.teardown.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_workspace_creation(self, tmp_path: Path) -> None:
         """Verify harness creates workspace directory at correct path."""

--- a/packages/decepticon/tests/unit/benchmark/test_provenance.py
+++ b/packages/decepticon/tests/unit/benchmark/test_provenance.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from benchmark.config import BenchmarkConfig
+from benchmark.provenance import (
+    ProvenanceCaptureError,
+    capture_container_images,
+    capture_declared_model_assignments,
+    capture_run_provenance,
+)
+from benchmark.reporter import Reporter
+from benchmark.runner import _build_run_provenance
+from benchmark.schemas import BenchmarkReport, Challenge, FilterConfig, RunProvenance
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def test_capture_run_provenance_records_source_artifacts_and_sanitized_config(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Benchmark Test")
+    _git(repo, "config", "user.email", "benchmark@example.invalid")
+
+    prompts = repo / "prompts"
+    skills = repo / "skills"
+    prompts.mkdir()
+    skills.mkdir()
+    (prompts / "agent.md").write_text("system prompt\n", encoding="utf-8")
+    (skills / "SKILL.md").write_text("skill body\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "fixture")
+    expected_commit = _git(repo, "rev-parse", "HEAD")
+
+    provenance = capture_run_provenance(
+        repo_root=repo,
+        config={
+            "provider": "xbow",
+            "timeout": 1800,
+            "api_key": "must-not-leak",
+            "litellm_url": (
+                "https://alice:secret@litellm.example/v1?token=must-not-leak&region=eu"
+            ),
+            "headers": {
+                "Authorization": "Bearer must-not-leak",
+                "Cookie": "session=must-not-leak",
+                "X-Signature": "must-not-leak",
+            },
+        },
+        model_profile="max",
+        model_assignments={"decepticon": ["anthropic/claude-opus-4-8"]},
+        container_images={"langgraph": "sha256:" + "c" * 64},
+        artifact_paths={"agent-prompts": prompts, "skill-corpus": skills},
+    )
+
+    assert provenance.source_commit == expected_commit
+    assert provenance.source_dirty is False
+    assert provenance.model_profile == "max"
+    assert provenance.model_assignments == {"decepticon": ["anthropic/claude-opus-4-8"]}
+    assert provenance.artifact_hashes == {
+        "agent-prompts": "22fea0014f60c17ea57f78d690000052103c49f3fcd1ecdf75789d8db70e0c61",
+        "skill-corpus": "6d5868b0afae30ab26935de97c3e1dece584b7f14a9ca8b01eb35e9225cadff8",
+    }
+    assert provenance.config == {
+        "provider": "xbow",
+        "timeout": 1800,
+        "api_key": "<redacted>",
+        "litellm_url": (
+            "https://<redacted>@litellm.example/v1?token=%3Credacted%3E&region=%3Credacted%3E"
+        ),
+        "headers": {
+            "Authorization": "<redacted>",
+            "Cookie": "<redacted>",
+            "X-Signature": "<redacted>",
+        },
+    }
+    assert provenance.run_id
+    assert provenance.python_version
+    assert provenance.platform
+
+
+def test_capture_run_provenance_marks_uncommitted_source(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Benchmark Test")
+    _git(repo, "config", "user.email", "benchmark@example.invalid")
+    tracked = repo / "tracked.txt"
+    tracked.write_text("before\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "fixture")
+    tracked.write_text("after\n", encoding="utf-8")
+
+    provenance = capture_run_provenance(
+        repo_root=repo,
+        config={"provider": "xbow"},
+        model_profile="test",
+        model_assignments={"decepticon": ["openai/gpt-5-nano"]},
+        container_images={"langgraph": "sha256:" + "d" * 64},
+        artifact_paths={"source": tracked},
+    )
+
+    assert provenance.source_dirty is True
+
+
+def test_capture_declared_model_assignments_uses_explicit_priority_and_role_override(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("DECEPTICON_AUTH_PRIORITY", "anthropic_api,openai_api")
+    runtime = {
+        "auth_priority": "anthropic_api,openai_api",
+        "profile": "max",
+        "assignments": {
+            "decepticon": ["plugin/custom-primary", "openai/gpt-5.5"],
+        },
+    }
+    monkeypatch.setattr(
+        "benchmark.provenance.subprocess.run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="DECEPTICON_PROVENANCE=" + json.dumps(runtime) + "\n",
+            stderr="",
+        ),
+    )
+
+    profile, assignments = capture_declared_model_assignments()
+
+    assert profile == "max"
+    assert assignments == {
+        "decepticon": ["plugin/custom-primary", "openai/gpt-5.5"],
+    }
+
+
+def test_capture_declared_models_rejects_container_priority_mismatch(monkeypatch) -> None:
+    monkeypatch.setenv("DECEPTICON_AUTH_PRIORITY", "anthropic_api,openai_api")
+    runtime = {
+        "auth_priority": "openai_api",
+        "profile": "max",
+        "assignments": {"decepticon": ["openai/gpt-5.5"]},
+    }
+    monkeypatch.setattr(
+        "benchmark.provenance.subprocess.run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="DECEPTICON_PROVENANCE=" + json.dumps(runtime),
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(ProvenanceCaptureError, match="effective models"):
+        capture_declared_model_assignments()
+
+
+def test_artifact_hash_ignores_generated_python_cache(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    prompts = repo / "prompts"
+    cache = prompts / "__pycache__"
+    cache.mkdir(parents=True)
+    (prompts / "agent.md").write_text("prompt\n", encoding="utf-8")
+    (cache / "agent.cpython-313.pyc").write_bytes(b"machine-specific")
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Benchmark Test")
+    _git(repo, "config", "user.email", "benchmark@example.invalid")
+    _git(repo, "add", "prompts/agent.md")
+    _git(repo, "commit", "-qm", "fixture")
+
+    arguments = {
+        "repo_root": repo,
+        "config": {"provider": "xbow"},
+        "model_profile": "test",
+        "model_assignments": {"decepticon": ["openai/gpt-5-nano"]},
+        "container_images": {"langgraph": "sha256:" + "d" * 64},
+        "artifact_paths": {"prompts": prompts},
+    }
+    with_cache = capture_run_provenance(**arguments)
+    (cache / "agent.cpython-313.pyc").unlink()
+    without_cache = capture_run_provenance(**arguments)
+
+    assert with_cache.artifact_hashes == without_cache.artifact_hashes
+
+
+def test_capture_container_images_prefers_registry_digest_and_keeps_local_image_id(
+    monkeypatch,
+) -> None:
+    def run_docker(argv, **_kwargs):
+        command = tuple(argv)
+        if command[:2] == ("docker", "ps"):
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout="ghcr.io/purpleailab/decepticon-langgraph:stable\n",
+                stderr="",
+            )
+        image = command[-1]
+        if image == "ghcr.io/purpleailab/decepticon-langgraph:stable":
+            stdout = (
+                '["ghcr.io/purpleailab/decepticon-langgraph@sha256:'
+                + "a" * 64
+                + '"]|sha256:'
+                + "b" * 64
+            )
+        else:
+            stdout = "[]|sha256:" + "c" * 64
+        return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("benchmark.provenance.subprocess.run", run_docker)
+
+    images = capture_container_images(["local/challenge:latest"])
+
+    assert images == {
+        "ghcr.io/purpleailab/decepticon-langgraph:stable": (
+            "ghcr.io/purpleailab/decepticon-langgraph@sha256:" + "a" * 64
+        ),
+        "local/challenge:latest": "sha256:" + "c" * 64,
+    }
+
+
+def test_capture_container_images_excludes_unrelated_running_projects(monkeypatch) -> None:
+    def run_docker(argv, **_kwargs):
+        command = tuple(argv)
+        if command[:2] == ("docker", "ps"):
+            output = (
+                "decepticon:stable\n"
+                if "--filter" in command
+                else "decepticon:stable\nunrelated:latest\n"
+            )
+            return subprocess.CompletedProcess(argv, 0, stdout=output, stderr="")
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout='["decepticon@sha256:' + "a" * 64 + '"]|sha256:' + "b" * 64,
+            stderr="",
+        )
+
+    monkeypatch.setattr("benchmark.provenance.subprocess.run", run_docker)
+
+    images = capture_container_images([])
+
+    assert set(images) == {"decepticon:stable"}
+
+
+def test_reporter_exposes_provenance_in_batch_index_and_markdown(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 30, tzinfo=timezone.utc)
+    report = BenchmarkReport(
+        provider_name="xbow",
+        provenance=RunProvenance(
+            run_id="run-001",
+            captured_at=now,
+            context_mode="hinted",
+            source_commit="1" * 40,
+            source_dirty=False,
+            benchmark_revisions={"benchmark/xbow-validation-benchmarks": "2" * 40},
+            model_profile="max",
+            model_assignments={"decepticon": ["anthropic/claude-opus-4-8"]},
+            artifact_hashes={"agent-prompts": "3" * 64},
+            container_images={"langgraph": "sha256:" + "4" * 64},
+            config={"provider": "xbow"},
+            python_version="3.13.7",
+            platform="linux-x86_64",
+        ),
+        total=0,
+        passed=0,
+        failed=0,
+        pass_rate=0.0,
+        by_level={},
+        by_tag={},
+        results=[],
+        started_at=now,
+        completed_at=now,
+        duration_seconds=0.0,
+    )
+    reporter = Reporter(tmp_path)
+
+    batch_dir = reporter.write_evidence(report)
+    markdown_path = reporter.write_markdown(report)
+
+    index = json.loads((batch_dir / "index.json").read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+    assert index["provenance"] == report.provenance.model_dump(mode="json")
+    assert "## Reproducibility" in markdown
+    assert "| Source Commit | `1111111111111111111111111111111111111111` |" in markdown
+    assert "| Context Mode | hinted |" in markdown
+    assert "| Model Profile | max |" in markdown
+
+
+def test_build_run_provenance_wires_runtime_inputs_into_reproducibility_record(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    prompts = tmp_path / "packages/decepticon/decepticon/agents/prompts"
+    skills = tmp_path / "packages/decepticon/decepticon/skills"
+    config_dir = tmp_path / "config"
+    prompts.mkdir(parents=True)
+    skills.mkdir(parents=True)
+    config_dir.mkdir()
+    (prompts / "decepticon.md").write_text("prompt\n", encoding="utf-8")
+    (skills / "SKILL.md").write_text("skill\n", encoding="utf-8")
+    challenge_dir = tmp_path / "benchmark/fixture"
+    challenge_dir.mkdir(parents=True)
+    (challenge_dir / "benchmark.json").write_text('{"id": "fixture"}\n', encoding="utf-8")
+    (config_dir / "litellm.yaml").write_text("model_list: []\n", encoding="utf-8")
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.name", "Benchmark Test")
+    _git(tmp_path, "config", "user.email", "benchmark@example.invalid")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "fixture")
+    monkeypatch.setattr(
+        "benchmark.runner.capture_declared_model_assignments",
+        lambda: (
+            "max",
+            {
+                "decepticon": [
+                    "auth/gpt-5.3-codex",
+                    "anthropic/claude-opus-4-8",
+                    "openai/gpt-5.5",
+                ]
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "benchmark.runner.capture_container_images",
+        lambda _refs: {"langgraph:stable": "sha256:" + "a" * 64},
+    )
+
+    provenance = _build_run_provenance(
+        config=BenchmarkConfig(provider="xbow", timeout=42),
+        filters=FilterConfig(levels=[3], tags=["ssti"]),
+        parallel=2,
+        challenges=[
+            Challenge(
+                id="XBEN-001-24",
+                name="fixture",
+                description="fixture",
+                level=3,
+                tags=["ssti"],
+                docker_image="challenge:latest",
+                compose_dir=challenge_dir,
+            )
+        ],
+        repo_root=tmp_path,
+    )
+
+    assert provenance.config["parallel"] == 2
+    assert provenance.model_assignments["decepticon"][0] == "auth/gpt-5.3-codex"
+    assert provenance.container_images == {"langgraph:stable": "sha256:" + "a" * 64}
+    assert "provider-definition" in provenance.artifact_hashes

--- a/packages/decepticon/tests/unit/benchmark/test_schemas.py
+++ b/packages/decepticon/tests/unit/benchmark/test_schemas.py
@@ -6,11 +6,15 @@ import re
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
 from benchmark.schemas import (
     BenchmarkReport,
     Challenge,
     ChallengeResult,
     FilterConfig,
+    RunProvenance,
     SetupResult,
 )
 
@@ -84,6 +88,33 @@ class TestBenchmarkReport:
         now = datetime.now(timezone.utc)
         report = BenchmarkReport(
             provider_name="xbow",
+            provenance={
+                "schema_version": 1,
+                "run_id": "run-20260830-001",
+                "captured_at": "2026-08-30T12:00:00Z",
+                "context_mode": "hinted",
+                "source_commit": "31e1c8e786c83bb20f5c3d9ebc482cf9fb8ffa06",
+                "source_dirty": False,
+                "benchmark_revisions": {
+                    "benchmark/xbow-validation-benchmarks": (
+                        "1c15c3289c6496446065adc254dd68104a2e372f"
+                    )
+                },
+                "model_profile": "max",
+                "model_assignments": {
+                    "decepticon": ["anthropic/claude-opus-4-8"],
+                },
+                "artifact_hashes": {
+                    "agent-prompts": "a" * 64,
+                    "skill-corpus": "b" * 64,
+                },
+                "container_images": {
+                    "langgraph": "ghcr.io/purpleailab/decepticon-langgraph@sha256:" + "c" * 64,
+                },
+                "config": {"provider": "xbow", "timeout": 1800},
+                "python_version": "3.13.7",
+                "platform": "Linux-x86_64",
+            },
             total=2,
             passed=1,
             failed=1,
@@ -120,9 +151,30 @@ class TestBenchmarkReport:
         assert restored.passed == 1
         assert restored.failed == 1
         assert restored.pass_rate == 0.5
+        assert restored.provenance.source_commit == "31e1c8e786c83bb20f5c3d9ebc482cf9fb8ffa06"
+        assert restored.provenance.context_mode == "hinted"
+        assert restored.provenance.model_assignments["decepticon"] == ["anthropic/claude-opus-4-8"]
         assert len(restored.results) == 2
         assert restored.results[0].passed is True
         assert restored.results[1].passed is False
+
+    def test_run_provenance_rejects_empty_mandatory_identity_maps(self) -> None:
+        with pytest.raises(ValidationError, match="container_images"):
+            RunProvenance(
+                run_id="run-001",
+                captured_at=datetime(2026, 8, 30, tzinfo=timezone.utc),
+                context_mode="hinted",
+                source_commit="1" * 40,
+                source_dirty=False,
+                benchmark_revisions={},
+                model_profile="max",
+                model_assignments={"decepticon": ["anthropic/claude-opus-4-8"]},
+                artifact_hashes={"agent-prompts": "2" * 64},
+                container_images={},
+                config={"provider": "xbow"},
+                python_version="3.13.7",
+                platform="linux-x86_64",
+            )
 
 
 class TestFilterConfig:

--- a/packages/decepticon/tests/unit/benchmark/test_scorer.py
+++ b/packages/decepticon/tests/unit/benchmark/test_scorer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from benchmark.schemas import ChallengeResult
+from benchmark.schemas import ChallengeResult, RunProvenance
 from benchmark.scorer import Scorer
 
 
@@ -23,6 +23,24 @@ def _make_result(
     )
 
 
+def _provenance() -> RunProvenance:
+    return RunProvenance(
+        run_id="run-001",
+        captured_at=datetime(2026, 8, 30, tzinfo=timezone.utc),
+        context_mode="hinted",
+        source_commit="1" * 40,
+        source_dirty=False,
+        benchmark_revisions={},
+        model_profile="test",
+        model_assignments={"decepticon": ["openai/gpt-5-nano"]},
+        artifact_hashes={"agent-prompts": "2" * 64},
+        container_images={"langgraph": "sha256:" + "3" * 64},
+        config={"provider": "test"},
+        python_version="3.13.7",
+        platform="linux-x86_64",
+    )
+
+
 class TestScorer:
     def _times(self) -> tuple[datetime, datetime]:
         start = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -38,12 +56,14 @@ class TestScorer:
             _make_result("C-003", 2, ["xss"], True),
         ]
 
-        report = Scorer.score(results, "test", start, end)
+        provenance = _provenance()
+        report = Scorer.score(results, "test", start, end, provenance=provenance)
 
         assert report.total == 3
         assert report.passed == 2
         assert report.failed == 1
         assert report.pass_rate == 2 / 3
+        assert report.provenance is provenance
 
     def test_score_by_level(self) -> None:
         """Verify by_level breakdown is computed correctly."""
@@ -55,7 +75,7 @@ class TestScorer:
             _make_result("C-004", 2, ["idor"], True),
         ]
 
-        report = Scorer.score(results, "test", start, end)
+        report = Scorer.score(results, "test", start, end, provenance=_provenance())
 
         assert report.by_level[1]["total"] == 3
         assert report.by_level[1]["passed"] == 2
@@ -72,7 +92,7 @@ class TestScorer:
             _make_result("C-002", 1, ["sqli", "web"], False),
         ]
 
-        report = Scorer.score(results, "test", start, end)
+        report = Scorer.score(results, "test", start, end, provenance=_provenance())
 
         assert report.by_tag["xss"]["total"] == 1
         assert report.by_tag["xss"]["passed"] == 1
@@ -87,7 +107,7 @@ class TestScorer:
     def test_score_empty_results(self) -> None:
         """Empty list produces report with total=0, pass_rate=0.0."""
         start, end = self._times()
-        report = Scorer.score([], "test", start, end)
+        report = Scorer.score([], "test", start, end, provenance=_provenance())
 
         assert report.total == 0
         assert report.passed == 0
@@ -104,7 +124,7 @@ class TestScorer:
             _make_result("C-002", 2, ["sqli"], True),
         ]
 
-        report = Scorer.score(results, "test", start, end)
+        report = Scorer.score(results, "test", start, end, provenance=_provenance())
 
         assert report.pass_rate == 1.0
         assert report.passed == 2
@@ -118,7 +138,7 @@ class TestScorer:
             _make_result("C-002", 2, ["sqli"], False),
         ]
 
-        report = Scorer.score(results, "test", start, end)
+        report = Scorer.score(results, "test", start, end, provenance=_provenance())
 
         assert report.pass_rate == 0.0
         assert report.passed == 0
@@ -131,7 +151,7 @@ class TestScorer:
         a.cost_usd = 0.123
         b = _make_result("C-002", 1, ["sqli"], False)
         b.cost_usd = 0.001
-        report = Scorer.score([a, b], "test", start, end)
+        report = Scorer.score([a, b], "test", start, end, provenance=_provenance())
         assert report.total_cost_usd is not None
         assert abs(report.total_cost_usd - 0.124) < 1e-9
 
@@ -141,7 +161,7 @@ class TestScorer:
         a = _make_result("C-001", 1, ["xss"], True)
         a.cost_usd = 0.05
         b = _make_result("C-002", 1, ["sqli"], False)  # cost_usd stays None
-        report = Scorer.score([a, b], "test", start, end)
+        report = Scorer.score([a, b], "test", start, end, provenance=_provenance())
         assert report.total_cost_usd == 0.05
 
     def test_total_cost_none_when_all_missing(self) -> None:
@@ -151,5 +171,5 @@ class TestScorer:
             _make_result("C-001", 1, ["xss"], True),
             _make_result("C-002", 1, ["sqli"], False),
         ]
-        report = Scorer.score(results, "test", start, end)
+        report = Scorer.score(results, "test", start, end, provenance=_provenance())
         assert report.total_cost_usd is None


### PR DESCRIPTION
## Summary

Benchmark reports now fail closed unless they carry a versioned reproducibility record for the exact source, benchmark inputs, live model routing, stack images, and challenge images that produced the result. The same provenance is emitted in JSON evidence, with a concise identity table in Markdown.

## Changes

- Capture source commit/dirty state, submodule revisions, provider/prompt/skill/config hashes, Python/platform, run ID, filters, and context mode before execution.
- Read credential-filtered, plugin-composed model chains from the live LangGraph container and require its explicit auth priority to match the benchmark process.
- Inspect challenge container image IDs while containers are running and propagate provenance failures through teardown so incomplete reports are never written.
- Redact sensitive config keys, every header value, URL user-info, and every URL query value.
- Require provenance in `BenchmarkReport`, `report.json`, `index.json`, and Markdown output.

## Intent

- **Issue / ADR this satisfies:** Closes #814
- **Anti-goal:** This PR does not change scoring, add repeated trials, or introduce blind evaluation.

## Blast radius

- [ ] **Tier-auto** — tests, internal refactors, non-policy docs, lockfile-only dep bumps.
- [x] **Tier-delegate** — agent prompts, skill bodies, middleware internals, web/CLI features.
- [ ] **Tier-supply-chain** — CI/workflows, package manifests and lockfiles, install script, compose / Dockerfiles, plugin contracts, `.semgrep/**`.

## Diff budget

- [x] My diff fits the budget.

The diff touches exactly 10 files and adds 399 runtime-code lines for one concern. The two longer provenance orchestration functions intentionally keep their fail-closed capture sequence visible; splitting them would create single-use forwarding helpers without reducing branching or risk.

## End-to-end verification

Ran `uv run pytest -q packages/decepticon/tests/unit/benchmark`: 128 passed and one pre-existing SDK-coupled test skipped. These tests execute the complete source/artifact/config capture against a real temporary Git repository, exercise reporter JSON/Markdown wiring, capture a running-container image ID before teardown, and verify that missing image identity propagates as `ProvenanceCaptureError`. Docker and the live LangGraph stack are unavailable in this workspace, so I could not execute a paid end-to-end benchmark run or `make smoke`; Docker/model boundaries were exercised with deterministic subprocess stand-ins instead, and that unverified live-stack surface is explicit here.

## Testing

- [ ] `make quality` passes (Python + CLI + Web)
- [ ] `make smoke` succeeds (clean local build + OSS-style up + health checks)
- [ ] `pytest tests/` passes (run this if you touched `docker-compose.yml` or `tests/`)
- [x] Every new/changed test was watched to fail without the change and pass with it
- [ ] Every new/changed code path was **executed on my machine**, not just unit-tested in isolation
- [x] Manual testing (describe): `make ci-lint` passed (ruff, format, basedpyright: 0 errors). `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy -u NO_PROXY -u no_proxy uv run pytest -n auto -q -m 'not slow' -k 'not test_ops_available_true_when_daemon_accepting'` passed: 5,140 passed, 45 skipped. A full `make ci-test` was also attempted; the only failure was the excluded existing AF_UNIX socket test because this workspace rejects socket creation with `EPERM`.

## Quality Bar self-check

- [x] No banned pattern from QUALITY_BAR appears in the diff.
- [x] No AI-slop signature survives.
- [x] Every changed line traces to the stated intent.
- [x] Every public function added/changed has explicit type annotations and every raised exception is named.
- [x] I would merge this PR if a stranger opened it.
- [x] I would still merge this at the end of a long review day.

## Related Issues

Closes #814
